### PR TITLE
Add support for Newsletter API

### DIFF
--- a/lib/WebService/SendGrid/Newsletter.pm
+++ b/lib/WebService/SendGrid/Newsletter.pm
@@ -1,0 +1,73 @@
+package WebService::SendGrid::Newsletter;
+use utf8;
+use Moose;
+use MooseX::Method::Signatures;
+BEGIN { extends 'WebService::SendGrid'; }
+
+# use WWW::Curl::Simple;
+use HTTP::Request;
+use JSON::XS;
+
+=head1 See SendGrid Documentation
+See http://docs.sendgrid.com/documentation/api/newsletter-api/newsletter/
+=cut
+
+method add (Str :$identity, Str :$name, Str :$subject, Str :$text, Str :$html) {
+    my %data;
+    $data{identity} = $identity;
+    $data{name} = $name;
+    $data{subject} = $subject;
+    $data{text} = $text;
+    $data{html} = $html;
+
+    my $req = $self->_generate_request('/api/newsletter/add.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method get (Str :$name) {
+    my %data;
+    $data{name} = $name;
+
+    my $req = $self->_generate_request('/api/newsletter/get.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 401);
+    return decode_json $res->content;
+}
+
+method edit (Str :$name, Str :$newname, Str :$identity, Str :$subject, Str :$text, Str :$html) {
+    my %data;
+    $data{name} = $name;
+    $data{newname} = $newname;
+    $data{identity} = $identity;
+    $data{subject} = $subject;
+    $data{text} = $text;
+    $data{html} = $html;
+
+    my $req = $self->_generate_request('/api/newsletter/edit.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method list (Str :$name?) {
+    my %data;
+    $data{name} = $name if ($name);
+
+    my $req = $self->_generate_request('/api/newsletter/list.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method delete (Str :$name) {
+    my %data;
+    $data{name} = $name;
+    my $req = $self->_generate_request('/api/newsletter/delete.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+1;

--- a/lib/WebService/SendGrid/Newsletter/List.pm
+++ b/lib/WebService/SendGrid/Newsletter/List.pm
@@ -1,0 +1,47 @@
+package WebService::SendGrid::Newsletter::List;
+use utf8;
+use Moose;
+use MooseX::Method::Signatures;
+use JSON::XS;
+
+BEGIN { extends 'WebService::SendGrid::Newsletter'; }
+
+=head1 See SendGrid Documentation
+See http://docs.sendgrid.com/documentation/api/newsletter-api/lists/
+
+Note that this module is List, not Lists.
+=cut
+
+method add (Str :$list, Str :$name?, ArrayRef :$columnname?) {
+    my %data;
+    $data{list} = $list;
+    $data{name} = $name if $name;
+    $data{columnname} = $columnname if $columnname;
+
+    my $req = $self->_generate_request('/api/newsletter/lists/add.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method get (Str :$list?) {
+    my %data;
+    $data{list} = $list if $list;    
+
+    my $req = $self->_generate_request('/api/newsletter/lists/get.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method delete (Str :$list?) {
+    my %data;
+    $data{list} = $list if $list;    
+
+    my $req = $self->_generate_request('/api/newsletter/lists/delete.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+1;

--- a/lib/WebService/SendGrid/Newsletter/List/Email.pm
+++ b/lib/WebService/SendGrid/Newsletter/List/Email.pm
@@ -1,0 +1,53 @@
+package WebService::SendGrid::Newsletter::List::Email;
+use utf8;
+use Moose;
+use MooseX::Method::Signatures;
+use JSON::XS;
+
+BEGIN { extends 'WebService::SendGrid::Newsletter'; }
+
+=head1 See SendGrid Documentation
+See http://docs.sendgrid.com/documentation/api/newsletter-api/lists/email/
+
+Note that this module is List::Email, not Lists::Email.
+=cut
+
+method add (Str :$list, ArrayRef :$data) {
+    my %request_data;
+    $request_data{list} = $list;
+    if (ref($data) eq 'ARRAY') {
+	my @data = map { encode_json($_) } @$data;
+	$request_data{data} = \@data;
+    } else {
+	$request_data{data} = $data;
+    }
+
+    my $req = $self->_generate_request('/api/newsletter/lists/email/add.json', \%request_data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method get (Str :$list, ArrayRef|Str :$email?) {
+    my %request_data;
+    $request_data{list} = $list if $list;    
+    $request_data{email} = $email;
+
+    my $req = $self->_generate_request('/api/newsletter/lists/email/get.json', \%request_data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method delete (Str :$list, ArrayRef|Str :$email?) {
+    my %request_data;
+    $request_data{list} = $list if $list;    
+    $request_data{email} = $email;
+
+    my $req = $self->_generate_request('/api/newsletter/lists/email/delete.json', \%request_data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+1;

--- a/lib/WebService/SendGrid/Newsletter/Recipient.pm
+++ b/lib/WebService/SendGrid/Newsletter/Recipient.pm
@@ -1,0 +1,49 @@
+package WebService::SendGrid::Newsletter::Recipient;
+use utf8;
+use Moose;
+use MooseX::Method::Signatures;
+use JSON::XS;
+
+BEGIN { extends 'WebService::SendGrid::Newsletter'; }
+
+=head1 See SendGrid documentation
+See http://docs.sendgrid.com/documentation/api/newsletter-api/recipients/
+
+Note that this module is Recipient, not Recipients.
+
+The delete method is untested.
+=cut
+
+method add (Str :$name, ArrayRef|Str :$list) {
+    my %data;
+    $data{name} = $name;
+    $data{list} = $list;
+
+    my $req = $self->_generate_request('/api/newsletter/recipients/add.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method get (Str :$name) {
+    my %data;
+    $data{name} = $name;
+
+    my $req = $self->_generate_request('/api/newsletter/recipients/get.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method delete (Str :$name, ArrayRef|Str :$list) {
+    my %data;
+    $data{name} = $name;
+    $data{list} = $list;
+
+    my $req = $self->_generate_request('/api/newsletter/recipients/delete.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+1;

--- a/lib/WebService/SendGrid/Newsletter/Schedule.pm
+++ b/lib/WebService/SendGrid/Newsletter/Schedule.pm
@@ -1,0 +1,45 @@
+package WebService::SendGrid::Newsletter::Schedule;
+use utf8;
+use Moose;
+use MooseX::Method::Signatures;
+use JSON::XS;
+
+BEGIN { extends 'WebService::SendGrid::Newsletter'; }
+
+=head1 See SendGrid documentation
+See http://docs.sendgrid.com/documentation/api/newsletter-api/schedule/
+=cut
+
+method add (Str :$name, Str :$at?, Str :$after?) {
+    my %data;
+    $data{name} = $name;
+    $data{at} = $at if $at;
+    $data{after} = $after if $after;
+
+    my $req = $self->_generate_request('/api/newsletter/schedule/add.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method get (Str :$name) {
+    my %data;
+    $data{name} = $name;
+
+    my $req = $self->_generate_request('/api/newsletter/schedule/get.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+method delete (Str :$name) {
+    my %data;
+    $data{name} = $name;
+
+    my $req = $self->_generate_request('/api/newsletter/schedule/delete.json', \%data);
+    my $res = $self->_dispatch_request($req);
+    return $self->_process_error($res) if ($res->code != 200 and $res->code != 100);
+    return decode_json $res->content;
+}
+
+1;


### PR DESCRIPTION
Thanks for a great component.

This adds support for Newsletter API documented at http://docs.sendgrid.com/documentation/api/newsletter-api/newsletter/

I can document the modules better if you approve these in the distribution. The modules should follow the patterns and conventions you've made earlier.

It appears the github version is still at 1.00 and not at 1.02, but these modules were made to work on top of 1.02, the latest version on CPAN.

Also suggest you add the github address in the main documentation and would love to have my name appear in the authors section if you so choose. :-)
